### PR TITLE
fix: change BASE_URL to localhost for development

### DIFF
--- a/api/core/consts.py
+++ b/api/core/consts.py
@@ -1,1 +1,2 @@
-BASE_URL = "https://plagl1.work.gd"
+# BASE_URL = "https://plagl1.work.gd"
+BASE_URL = "http://localhost:8000"


### PR DESCRIPTION
Update the BASE_URL constant to point to local development server instead of production